### PR TITLE
Update upper bound for package_info_plus dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   collection: ^1.17.0
-  package_info_plus: '>=4.0.2 <6.0.0'
+  package_info_plus: '>=4.0.2 <9.0.0'
   device_info_plus: ^9.0.0
   split_view: ^3.2.1
 


### PR DESCRIPTION
This makes flutter_debug_overlay compatible with the latest release of [package_info_plus](https://pub.dev/packages/package_info_plus) (v8.0.0)